### PR TITLE
Enabled component display in custom tabs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ To use this component:
        src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
 </a>
 
+## Why this fork?
+
+When attempting to add Troy Hedges' original [PSKnowledgeHierarchyViewer](https://github.com/thedges/PSKnowledgeHierarchyViewer) plugin on a dedicated custom tab, as per Salesforce's documentation, [Add Lightning Components as Custom Tabs in a Lightning App](https://help.salesforce.com/s/articleView?id=sf.aura_add_cmp_lex.htm&type=5), the component was unavailable. It also looks like development of the plugin has ceased.
+
+Consulting the [Lightning Web Components Developer Guide: Configure Components for Custom Tabs](https://developer.salesforce.com/docs/platform/lwc/guide/use-config-custom-tab.html) docs indicate a quick addition to the Lightning Component configuration that enables addition to custom tabs.
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PSKnowledgeHierarchyViewer
+# SFDC-KnowledgebaseHierarchy
 Demo component to show ability for a Knowledge hierarchy viewer
 
 THIS SOFTWARE IS COVERED BY [THIS DISCLAIMER](https://raw.githubusercontent.com/thedges/Disclaimer/master/disclaimer.txt).
@@ -30,9 +30,9 @@ This component currently has no configuration properties.
 To use this component:
 1. Install the component using the **'Deploy to Salesforce'** button below.
 2. Assign the **PSKnowledgeHierarchyViewer** permission set to any user that will use this component.
-2. Drag the **psKnowledgeHierarchyViewer** Lightning Component on to your page. That's it.
+3. Drag the **psKnowledgeHierarchyViewer** Lightning Component on to your page. That's it.
 
-<a href="https://githubsfdeploy.herokuapp.com">
+<a href="https://githubsfdeploy.herokuapp.com?owner=watchmaker-genomics&repo=SFDC-KnowledgebaseHierarchy&ref=master">
   <img alt="Deploy to Salesforce"
        src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/deploy.png">
 </a>

--- a/src/lwc/psKnowledgeHierarchyViewer/psKnowledgeHierarchyViewer.js-meta.xml
+++ b/src/lwc/psKnowledgeHierarchyViewer/psKnowledgeHierarchyViewer.js-meta.xml
@@ -6,6 +6,7 @@
         <target>lightning__AppPage</target>
         <target>lightning__RecordPage</target>
         <target>lightning__HomePage</target>
+        <target>lightning__Tab</target>
         <target>lightningCommunity__Page</target>
         <target>lightningCommunity__Default</target>
     </targets>


### PR DESCRIPTION
Minor addition to enable showing the PSKnowledgeHierarchyViewer Lightning component on/in custom Salesforce tabs.

### Reference:
1. [Lightning Web Components Developer Guide: Configure Components for Custom Tabs](https://developer.salesforce.com/docs/platform/lwc/guide/use-config-custom-tab.html)